### PR TITLE
fix(android): remove READ_MEDIA_IMAGES and READ_MEDIA_VIDEO permissions

### DIFF
--- a/src/android/FileUtils.java
+++ b/src/android/FileUtils.java
@@ -537,7 +537,7 @@ public class FileUtils extends CordovaPlugin {
         int requestCode = pendingRequests.createRequest(rawArgs, action, callbackContext);
         if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             PermissionHelper.requestPermissions(this, requestCode,
-                    new String[]{Manifest.permission.READ_MEDIA_IMAGES, Manifest.permission.READ_MEDIA_VIDEO, Manifest.permission.READ_MEDIA_AUDIO});
+                    new String[]{Manifest.permission.READ_MEDIA_AUDIO});
         } else {
             PermissionHelper.requestPermission(this, requestCode, Manifest.permission.READ_EXTERNAL_STORAGE);
         }
@@ -561,9 +561,7 @@ public class FileUtils extends CordovaPlugin {
      */
     private boolean hasReadPermission() {
         if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            return PermissionHelper.hasPermission(this, Manifest.permission.READ_MEDIA_IMAGES)
-                    && PermissionHelper.hasPermission(this, Manifest.permission.READ_MEDIA_VIDEO)
-                    && PermissionHelper.hasPermission(this, Manifest.permission.READ_MEDIA_AUDIO);
+            return PermissionHelper.hasPermission(this, Manifest.permission.READ_MEDIA_AUDIO);
         } else {
             return PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE);
         }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
https://trello.com/c/Xh7UBWwo/1377-chore-look-into-android-image-and-video-permissions-1

https://support.google.com/googleplay/android-developer/answer/9888170?hl=en
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->
Simply removes the usage of READ_MEDIA_IMAGES and READ_MEDIA_VIDEO permissions.

We believe this to be safe ONLY FOR OUR VERY SPECIFIC USE OF THIS PLUGIN. We do not use this plugin to get photos/videos from the filesystem. This change will likely break that.



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
